### PR TITLE
Fix image overflow when media screen is smaller than 980px

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -369,6 +369,12 @@ Full-Width Styles
 Small Device Styles
 *******************************************************************************/
 
+@media screen and (max-width: 992px) {
+  img {
+    max-width: 100%;
+  }
+}
+
 @media screen and (max-width: 480px) {
   body {
     font-size:14px;


### PR DESCRIPTION
When the screen width is too small (e.g. view in mobile device), some large image may overflow.

To fix this, I make the img becomes `max-width: 100%;` when media screen is below 992px. 992px is Medium Devices Desktops in Bootstrap. Hopefully only 1 line of css for this break-point is not too rare.

> p.s. Put the line in max-width: 480px is not enough. And, for medium devices, fixing a certain width for images may be too small. That's why I make it 100%.