### PR TITLE
Extract includes from default.html

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,8 @@
+<div id="footer_wrap" class="outer">
+  <footer class="inner">
+    {% if site.github.is_project_page %}
+    <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+    {% endif %}
+    <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
+  </footer>
+</div>

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,8 @@
+<script type="text/javascript">
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', '{{ site.google_analytics }}', 'auto');
+  ga('send', 'pageview');
+</script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,10 @@
+<head>
+  <meta charset='utf-8'>
+  <meta http-equiv="X-UA-Compatible" content="chrome=1">
+  <meta name="viewport" content="width=device-width,maximum-scale=2">
+  <meta name="description" content="{{ site.title | default: site.github.repository_name }} : {{ site.description | default: site.github.project_tagline }}">
+
+  <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+
+  <title>{{ site.title | default: site.github.repository_name }}</title>
+</head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,4 +7,8 @@
   <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
 
   <title>{{ site.title | default: site.github.repository_name }}</title>
+
+  {% if site.google_analytics %}
+  {% include google-analytics.html %}
+  {% endif %}
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,15 @@
+<div id="header_wrap" class="outer">
+  <header class="inner">
+    <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+
+    <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
+    <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
+
+    {% if site.show_downloads %}
+    <section id="downloads">
+      <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
+      <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
+    </section>
+    {% endif %}
+  </header>
+</div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,9 +14,5 @@
     </div>
 
     {% include footer.html %}
-
-    {% if site.google_analytics %}
-    {% include google-analytics.html %}
-    {% endif %}
   </body>
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,62 +1,22 @@
 <!DOCTYPE html>
 <html>
 
-  <head>
-    <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="viewport" content="width=device-width,maximum-scale=2">
-    <meta name="description" content="{{ site.title | default: site.github.repository_name }} : {{ site.description | default: site.github.project_tagline }}">
-
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
-
-    <title>{{ site.title | default: site.github.repository_name }}</title>
-  </head>
+  {% include head.html %}
 
   <body>
 
-    <!-- HEADER -->
-    <div id="header_wrap" class="outer">
-        <header class="inner">
-          <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+    {% include header.html %}
 
-          <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
-          <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
-
-          {% if site.show_downloads %}
-            <section id="downloads">
-              <a class="zip_download_link" href="{{ site.github.zip_url }}">Download this project as a .zip file</a>
-              <a class="tar_download_link" href="{{ site.github.tar_url }}">Download this project as a tar.gz file</a>
-            </section>
-          {% endif %}
-        </header>
-    </div>
-
-    <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
         {{ content }}
       </section>
     </div>
 
-    <!-- FOOTER  -->
-    <div id="footer_wrap" class="outer">
-      <footer class="inner">
-        {% if site.github.is_project_page %}
-        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
-        {% endif %}
-        <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
-      </footer>
-    </div>
+    {% include footer.html %}
 
     {% if site.google_analytics %}
-      <script type="text/javascript">
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-        ga('create', '{{ site.google_analytics }}', 'auto');
-        ga('send', 'pageview');
-      </script>
+    {% include google-analytics.html %}
     {% endif %}
   </body>
 </html>


### PR DESCRIPTION
This extracts parts of default.html into includes along the same structure as [minima](https://github.com/jekyll/minima).  I contribute to a project that uses GitHub pages and this theme, and now it to add more content than a single page.  This was done as a first step towards adding support in the theme for more layout types.

Aside from white space differences and moving the Googe Analytics to a more traditional place in `head` this makes a point not to change the generated output.