### PR TITLE
Add CSS to support smaller mobile devices

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -423,3 +423,53 @@ Small Device Styles
   }
 
 }
+
+@media screen and (max-width: 320px) {
+  body {
+    font-size:14px;
+  }
+
+  #downloads {
+    display: none;
+  }
+
+  .inner {
+    min-width: 240px;
+    max-width: 320px;
+  }
+
+  #project_title {
+  font-size: 28px;
+  }
+
+  h1 {
+    font-size: 24px;
+  }
+
+  h2 {
+    font-size: 21px;
+  }
+
+  h3 {
+    font-size: 18px;
+  }
+
+  h4 {
+    font-size: 16px;
+  }
+
+  h5 {
+    font-size: 14px;
+  }
+
+  h6 {
+    font-size: 12px;
+  }
+
+  code, pre {
+    min-width: 240px;
+    max-width: 320px;
+    font-size: 11px;
+  }
+
+}


### PR DESCRIPTION
This change adds support for the "classic" iPhone width. Style copied directly from existing 480px width with necessary width and font modifications. To view proposed changes on an active site, visit jazzace.github.io.