### PR TITLE
Format <cite> tagged text as italics

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -123,7 +123,7 @@ footer a {
   text-decoration: underline;
 }
 
-em {
+em, cite {
   font-style: italic;
 }
 


### PR DESCRIPTION
Just a minor change to the CSS. Text tagged as \<cite\> should be shown in italics.