### PR TITLE
_sass/jekyll-theme-slate.scss: Remove bold style of hyperlinks on hover.

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -115,7 +115,6 @@ a {
 
 a:hover, a:focus {
   text-decoration: underline;
-  font-weight:bold;
 }
 
 footer a {


### PR DESCRIPTION
This fixes a text flickering issue.

It was introduced in ef69e5aa955c115eeaa2b670d5c74ee79a4d89fc, whose
commit message said 'fixing up color contrast issues'. On some browsers,
bold text is rendered longer and takes up more space than normal text.
Hence making hyperlinks bold on hover pushes everything after a link
afterwards.

Discussion: https://github.com/pages-themes/slate/commit/ef69e5aa955c115eeaa2b670d5c74ee79a4d89fc#diff-0c98b278830c5f885e539016b209473cR118
Signed-off-by: Liu Hao <lh_mouse@126.com>