### PR TITLE
Make usage of <code> in headers *not* ugly

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -159,7 +159,7 @@ pre, code {
   background-color: #fff;
 
   font-family: Monaco, "Bitstream Vera Sans Mono", "Lucida Console", Terminal, monospace;
-  font-size: 14px;
+  font-size: 0.875em;
 
   border-radius: 2px;
   -moz-border-radius: 2px;


### PR DESCRIPTION
0.875 is 14/16 (16px being the default font size specified in the rule for \<body\>).
This way usage of \<code\> elements will not be ugly since the font size will be relatively scaled (e.g. 28px instead of 14px for \<h2\> with default size 32px).

Example of ugliness:
https://toughengineer.github.io/talks/C++%20Siberia%202020/