### PR TITLE
Images should not be allowed to grow outside the bounds of text.

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -133,7 +133,7 @@ strong {
 img {
   position: relative;
   margin: 0 auto;
-  max-width: 739px;
+  max-width: 100%;
   padding: 5px;
   margin: 10px 0 10px 0;
   border: 1px solid #ebebeb;


### PR DESCRIPTION
I'm not sure why, but the maximum with of images is larger than the width of the text. This allows the image to grow to the right of the text. If that is intended, it should at least be centered. But I prefer a max-width of 100%.