### PR TITLE
Add word-wrap to body tag

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -51,6 +51,7 @@ body {
   font-family: 'Myriad Pro', Calibri, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  word-wrap: normal;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Long unbroken strings (such as links) break the layout on mobile as they stretch the page width out and make the text unreadable. e.g. https://anonymousplanet.github.io/thgtoa/guide.html