### PR TITLE
Make usage of <code> in headers *not* ugly

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -418,7 +418,7 @@ Small Device Styles
   }
 
   code, pre {
-    font-size: 11px;
+    font-size: 0,688em;
   }
 
 }
@@ -468,7 +468,7 @@ Small Device Styles
   code, pre {
     min-width: 240px;
     max-width: 320px;
-    font-size: 11px;
+    font-size: 0,688em;
   }
 
 }


### PR DESCRIPTION
0.688is 11/16 (16px being the default font size specified in the rule for <body>).
This way usage of <code> elements will not be ugly since the font size will be relatively scaled (e.g. 28px instead of 14px for <h2> with default size 32px).

Explained here:
https://github.com/pages-themes/slate/pull/34

Example of ugliness:
https://toughengineer.github.io/talks/C++%20Siberia%202020/