### PR TITLE
Make usage of <code> in headers *not* ugly on small device screens

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -432,7 +432,7 @@ Small Device Styles
   }
 
   code, pre {
-    font-size: 11px;
+    font-size: 0.7857em;
   }
 
 }
@@ -482,7 +482,7 @@ Small Device Styles
   code, pre {
     min-width: 240px;
     max-width: 320px;
-    font-size: 11px;
+    font-size: 0.7857em;
   }
 
 }

--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -432,7 +432,7 @@ Small Device Styles
   }
 
   code, pre {
-    font-size: 0.78571em;
+    font-size: 0.7857em;
   }
 
 }
@@ -482,7 +482,7 @@ Small Device Styles
   code, pre {
     min-width: 240px;
     max-width: 320px;
-    font-size: 0.78571em;
+    font-size: 0.7857em;
   }
 
 }

--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -432,7 +432,7 @@ Small Device Styles
   }
 
   code, pre {
-    font-size: 0.7857em;
+    font-size: 0.78571em;
   }
 
 }
@@ -482,7 +482,7 @@ Small Device Styles
   code, pre {
     min-width: 240px;
     max-width: 320px;
-    font-size: 0.7857em;
+    font-size: 0.78571em;
   }
 
 }


### PR DESCRIPTION
This is similar to
Make usage of \<code\> in headers *not* ugly #34
and fixes the issue for small screens.

The base font size is 14px, the size of `code` and `pre` elements is supposed to be 11px.
11/14 = 0.7(857142857142), 0.7857 seems to be the good place to truncate it.
So for 14px base size `code` and `pre` size will be
14px*0.7857 = 10,9998px which is very close to 11px.

Before the fix:
![toughengineer github io_talks_2023_C++%20Russia_(Samsung Galaxy S8+)](https://github.com/pages-themes/slate/assets/20643126/4cccc544-eb66-4083-8ce0-3665a60393c0)

After the fix:
![toughengineer github io_talks_2023_C++%20Russia_(Samsung Galaxy S8+) (1)](https://github.com/pages-themes/slate/assets/20643126/6f987b4e-b6d8-409d-8914-59fb514386fe)
