### PR TITLE
Add hint on "View on GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ show_downloads: ["true" or "false" (unquoted) to indicate whether to provide a d
 google_analytics: [Your Google Analytics tracking ID]
 ```
 
+### Show "View on GitHub" button
+
+Slate will show a button to navigate to the respective GitHub repsotiroy, if set in your site's `_config.yml`:
+
+```yml
+github:
+  is_project_page: true
+```
+
+Default is `false`.
+
 ### Stylesheet
 
 If you'd like to add your own custom styles:


### PR DESCRIPTION
This adds a hint how to activate the button "View on GitHub"

Screenshot of site containing this button:

![image](https://github.com/pages-themes/slate/assets/1366654/be99e5d8-51fe-4c0f-8e95-f5cb353b6216)

This closes https://github.com/pages-themes/slate/pull/57.
