### PR TITLE
Restore sub/sup positioning

### DIFF
--- a/_sass/jekyll-theme-slate.scss
+++ b/_sass/jekyll-theme-slate.scss
@@ -130,6 +130,14 @@ strong {
   font-weight: bold;
 }
 
+sub {
+  font-variant-position: sub;
+}
+
+sup {
+  font-variant-position: super;
+}
+
 img {
   position: relative;
   margin: 0 auto;


### PR DESCRIPTION
The MeyerWeb reset sets `font-variant-position: normal` on `<sub>` and `<sup>` tags, so they look the same as regular text.

This PR restores the appropriate font-variant-positioning values, similar to what's already done for `<strong>`, `<em>` etc...

Fixes #40