### PR TITLE
Use "<repo> is maintained by <user>" instead of "<repo> maintained by <user>"

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -43,7 +43,7 @@
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         {% if site.github.is_project_page %}
-        <p class="copyright">{{ site.title | default: site.github.repository_name }} maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
+        <p class="copyright">{{ site.title | default: site.github.repository_name }} is maintained by <a href="{{ site.github.owner_url }}">{{ site.github.owner_name }}</a></p>
         {% endif %}
         <p>Published with <a href="https://pages.github.com">GitHub Pages</a></p>
       </footer>


### PR DESCRIPTION
"\<repo\> maintained by \<user\>" sounds a bit rough to me. I think the "is" improves readability.