### PR TITLE
Updating Google Tag Setup to Align with the Current Standard

### DIFF
--- a/_includes/head-custom-google-analytics.html
+++ b/_includes/head-custom-google-analytics.html
@@ -1,10 +1,11 @@
 {% if site.google_analytics %}
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    ga('create', '{{ site.google_analytics }}', 'auto');
-    ga('send', 'pageview');
-  </script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>
 {% endif %}


### PR DESCRIPTION
Updating Google Tag Setup to Align with the Current Standard.

The Google Tag setup in jekyll-theme-slate wasn’t working for me. When I visited the page, Google Analytics wasn’t recording any data.

To fix this, I updated the content of _includes/head-custom-google-analytics.html to match the latest implementation described under: https://developers.google.com/tag-platform/gtagjs#add_the_google_tag_to_your_website

After making this change, Google Analytics started working correctly.